### PR TITLE
Bugfix/parallel job names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # GitlabCiLocal IntelliJ plugin Changelog
 
+## [0.0.6] - 2024-06-07
+Fix the command creation for jobs using parallel:matrix
+
 ## [0.0.5] - 2023-08-19
 Updated to work on newer Intellij platforms.
 Should be more robust now on excluding .gitlab-ci-local folder.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = dk.cego.gitlab_ci_local_plugin
 pluginName = GitlabCiLocal IntelliJ Plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.5
+pluginVersion = 0.0.6
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/kotlin/dk/cego/gitlab_ci_local_plugin/GclRunConfiguration.kt
+++ b/src/main/kotlin/dk/cego/gitlab_ci_local_plugin/GclRunConfiguration.kt
@@ -34,7 +34,9 @@ class GclRunConfiguration(project: Project?, factory: ConfigurationFactory?, nam
         return object : CommandLineState(executionEnvironment) {
             @Throws(ExecutionException::class)
             override fun startProcess(): ProcessHandler {
-                val script = listOf(scriptName!!) + name.split(" ")
+                val needs = name.contains("--needs")
+                val job = name.split("--")[0].trim()
+                val script = listOf(scriptName!!) + job + (if (needs) "--needs" else "--no-needs")
                 val commandLine = PtyCommandLine(WslUtils.rewriteToWslExec(project.basePath!!, script)).withInitialColumns(PtyCommandLine.MAX_COLUMNS)
                 commandLine.workDirectory = File(project.basePath!!)
                 commandLine.charset = Charsets.UTF_8


### PR DESCRIPTION
If a job uses the parallel:matrix pattern the script created splits the job name as it is e.g. 'kotlin:test [stabilisation]'. This will result in the error `kotlin:test:,[stabilisation] could not be found`